### PR TITLE
chore:Add site-generated text generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,10 @@ jobs:
         env:
           GSTORAGE_API_KEY: ${{ secrets.GSTORAGE_API_KEY }}
 
+      # ensure that at least 1 file gets committed
+      - name: Update site-generated.txt
+        run: date > public/api/data/site-generated.txt
+
       - name: Update catalog items if needed
         run: cd public/api/data && git add . && cd ../../..
 
@@ -64,7 +68,7 @@ jobs:
         run: |
           git config --global user.name 'CI:Butch Landingin'
           git config --global user.email 'butchtm@users.noreply.github.com'
-          git commit -m "ci:Refresh catalog item and assets"
+          git commit -m "ci:Refresh catalog items, site-generated and assets"
           git push
 
       - name: Upload production-ready build files


### PR DESCRIPTION


## Add site-generated.txt in api/data/folder

- fix: Add a dynamic `site-generated.txt` file in `api/data/` that holds the date/time the site was last generated. 

## Extra details

This is to ensure that the commit step in the deploy job has at least 1 file to commit and does not error out